### PR TITLE
Feat: file version provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A framework to simplify application creation by improving dependency injection, 
 - Asp Net Core
   - Blazor render component in controller
   - Clear hosted lifecycle
+  - File version provider
 
 ## Example simple usage
 
@@ -343,3 +344,7 @@ public class MyWorker : AbstractHostedLifecycleService
 - [Config.Net](https://github.com/aloneguid/config)
 - [FluentValidation](https://docs.fluentvalidation.net/en/latest/)
 - [EntityFramework](https://learn.microsoft.com/en-us/ef/core/)
+
+## License
+The entire project, except for the file [FileVersionProvider.cs](TakasakiStudio.Lina.AspNet/Providers/FileVersionProvider.cs) is licensed under the [The Unlicense license](LICENSE).
+The file FileVersionProvider.cs was copied from [Asp.NET Core](https://github.com/dotnet/aspnetcore/blob/6dfaf9e2cff6cfa3aab0b7842fe02fe9f71e0f60/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs) under the MIT License.

--- a/TakasakiStudio.Lina.AspNet/Extensions/ServiceProviderExtension.cs
+++ b/TakasakiStudio.Lina.AspNet/Extensions/ServiceProviderExtension.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.DependencyInjection;
+using TakasakiStudio.Lina.AspNet.Providers;
+
+namespace TakasakiStudio.Lina.AspNet.Extensions;
+
+public static class ServiceProviderExtension
+{
+    public static void AddFileVersionProvider(this IServiceCollection services)
+    {
+        services.AddSingleton<IFileVersionProvider, FileVersionProvider>();
+    }
+}

--- a/TakasakiStudio.Lina.AspNet/Providers/FileVersionProvider.cs
+++ b/TakasakiStudio.Lina.AspNet/Providers/FileVersionProvider.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file under the MIT license.
+// Source code from https://github.com/dotnet/aspnetcore/blob/6dfaf9e2cff6cfa3aab0b7842fe02fe9f71e0f60/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs
+//
+// The MIT License (MIT)
+// 
+// Copyright (c) .NET Foundation and Contributors
+// 
+// All rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.FileProviders;
+
+namespace TakasakiStudio.Lina.AspNet.Providers;
+
+public class FileVersionProvider(IWebHostEnvironment hostingEnvironment) : IFileVersionProvider
+{
+    private const string VersionKey = "v";
+    private IMemoryCache Cache { get; } = new MemoryCache(new MemoryCacheOptions()
+    {
+        SizeLimit = 10485760L
+    });
+
+    private IFileProvider FileProvider { get; } = hostingEnvironment.WebRootFileProvider;
+    
+    public string AddFileVersionToPath(PathString requestPathBase, string path)
+    {
+        var resolvedPath = path;
+
+        var queryStringOrFragmentStartIndex = path.AsSpan().IndexOfAny('?', '#');
+        if (queryStringOrFragmentStartIndex != -1)
+            resolvedPath = path[..queryStringOrFragmentStartIndex];
+
+        if (Uri.TryCreate(resolvedPath, UriKind.Absolute, out var uri) && !uri.IsFile)
+            return path;
+
+        if (Cache.TryGetValue<string>(path, out var value) && value is not null)
+            return value;
+
+        var cacheEntryOptions = new MemoryCacheEntryOptions();
+        cacheEntryOptions.AddExpirationToken(FileProvider.Watch(resolvedPath));
+        var fileInfo = FileProvider.GetFileInfo(resolvedPath);
+
+        if (!fileInfo.Exists &&
+            requestPathBase.HasValue &&
+            resolvedPath.StartsWith(requestPathBase.Value, StringComparison.OrdinalIgnoreCase))
+        {
+            var requestPathBaseRelativePath = resolvedPath[requestPathBase.Value.Length..];
+            cacheEntryOptions.AddExpirationToken(FileProvider.Watch(requestPathBaseRelativePath));
+            fileInfo = FileProvider.GetFileInfo(requestPathBaseRelativePath);
+        }
+
+        value = fileInfo.Exists ? QueryHelpers.AddQueryString(path, VersionKey, GetHashForFile(fileInfo)) :
+            path;
+
+        cacheEntryOptions.SetSize(value.Length * sizeof(char));
+        Cache.Set(path, value, cacheEntryOptions);
+        return value;
+    }
+
+    private static string GetHashForFile(IFileInfo fileInfo)
+    {
+        using var readStream = fileInfo.CreateReadStream();
+        var hash = SHA256.HashData(readStream);
+        return WebEncoders.Base64UrlEncode(hash);
+    }
+}

--- a/TakasakiStudio.Lina.AspNet/TakasakiStudio.Lina.AspNet.csproj
+++ b/TakasakiStudio.Lina.AspNet/TakasakiStudio.Lina.AspNet.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>TakasakiStudio.Lina.AspNet</PackageId>
         <Authors>TakasakiStudio</Authors>

--- a/TakasakiStudio.Lina.AutoDependencyInjection/TakasakiStudio.Lina.AutoDependencyInjection.csproj
+++ b/TakasakiStudio.Lina.AutoDependencyInjection/TakasakiStudio.Lina.AutoDependencyInjection.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>TakasakiStudio.Lina.AutoDependencyInjection</PackageId>
         <Authors>TakasakiStudio</Authors>

--- a/TakasakiStudio.Lina.Common/TakasakiStudio.Lina.Common.csproj
+++ b/TakasakiStudio.Lina.Common/TakasakiStudio.Lina.Common.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>TakasakiStudio.Lina.Common</PackageId>
         <Title>TakasakiStudio.Lina.Common</Title>

--- a/TakasakiStudio.Lina.Database/TakasakiStudio.Lina.Database.csproj
+++ b/TakasakiStudio.Lina.Database/TakasakiStudio.Lina.Database.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>TakasakiStudio.Lina.Database</PackageId>
         <Title>TakasakiStudio.Lina.Database</Title>

--- a/TakasakiStudio.Lina.Utils/TakasakiStudio.Lina.Utils.csproj
+++ b/TakasakiStudio.Lina.Utils/TakasakiStudio.Lina.Utils.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>TakasakiStudio.Lina.Utils</PackageId>
         <Title>TakasakiStudio.Lina.Utils</Title>

--- a/TakasakiStudio.Lina/TakasakiStudio.Lina.csproj
+++ b/TakasakiStudio.Lina/TakasakiStudio.Lina.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <Version>2.0.8</Version>
+        <Version>2.0.9</Version>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <PackageId>TakasakiStudio.Lina</PackageId>
         <Title>TakasakiStudio.Lina</Title>


### PR DESCRIPTION
Adds the FileVersionProvider implementation, since [the Asp.NET Core one is `internal`](https://github.com/dotnet/aspnetcore/blob/6dfaf9e2cff6cfa3aab0b7842fe02fe9f71e0f60/src/Mvc/Mvc.Razor/src/Infrastructure/DefaultFileVersionProvider.cs).
This feature is intended to be used on Blazor apps, because you can't use IFileVersionProvider without [adding the Asp.NET MVC services](https://github.com/dotnet/aspnetcore/blob/6dfaf9e2cff6cfa3aab0b7842fe02fe9f71e0f60/src/Mvc/Mvc.Razor/src/DependencyInjection/MvcRazorMvcCoreBuilderExtensions.cs#L153).

Also bumps version to 2.0.9.